### PR TITLE
Changed Makefile to work for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /bin
+/obj
+/sfml
+/sfml.zip
 .vscode

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,7 @@
         "cwd": "${workspaceFolder}",
         "environment": [],
         "externalConsole": true,
-        "MIMode": "lldb"
+        "MIMode": "lldb",
+        "miDebuggerPath": "C:\\ProgramData\\chocolatey\\bin\\gdb.exe"
     }]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,58 @@
+# choco install mingw unzip curl
+
 TARGET_EXEC ?= square
 
 CC=gcc
 CXX=g++
 
 BIN_DIR ?= ./bin
-SRC_DIRS ?= ./src
+OBJ_DIR ?= ./obj
+SRC_DIR ?= ./src
 
 LIBS := sfml-graphics sfml-window sfml-system
-SRCS := $(shell find $(SRC_DIRS) -name *.cpp -or -name *.c -or -name *.s)
-OBJS := $(SRCS:%=$(BIN_DIR)/%.o)
+DLLS := $(LIBS:%=$(BIN_DIR)/%-2.dll)
+SRCS := $(shell find $(SRC_DIR) -name *.cpp -or -name *.c -or -name *.s)
+OBJS := $(SRCS:$(SRC_DIR)/%=$(OBJ_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
-INC_DIRS := $(shell find $(SRC_DIRS) -type d)
+INC_DIRS := $(shell find $(SRC_DIR) -type d)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
+INC_FLAGS := $(INC_FLAGS) -Isfml/SFML-2.5.1/include
 
-LDFLAGS := $(shell pkg-config --libs $(LIBS))
+# LDFLAGS := $(shell pkg-config --libs $(LIBS))
+LDFLAGS := -Lsfml/SFML-2.5.1/lib $(addprefix -l,$(LIBS))
 
-CPPFLAGS := $(INC_FLAGS) -g -MMD -MP $(shell pkg-config --cflags $(LIBS))
+CPPFLAGS := $(INC_FLAGS) -g -MMD -MP
 
-$(BIN_DIR)/$(TARGET_EXEC): $(OBJS)
+$(BIN_DIR)/$(TARGET_EXEC): $(DLLS) sfml $(OBJS)
+	$(MKDIR_P) $(dir $@)
 	$(CXX) $(OBJS) -o $@ $(LDFLAGS)
 
+$(BIN_DIR)/%.dll: sfml
+	$(MKDIR_P) $(dir $@)
+	echo $@
+	cp sfml/SFML-2.5.1/$@ $@
+
 # assembly
-$(BIN_DIR)/%.s.o: %.s
+$(OBJ_DIR)/%.s.o: %.s
 	$(MKDIR_P) $(dir $@)
 	$(AS) $(ASFLAGS) -c $< -o $@
 
 # c source
-$(BIN_DIR)/%.c.o: %.c
+$(OBJ_DIR)/%.c.o: %.c
 	$(MKDIR_P) $(dir $@)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 # c++ source
-$(BIN_DIR)/%.cpp.o: %.cpp
+$(OBJS): $(OBJ_DIR)/%.cpp.o : $(SRC_DIR)/%.cpp
 	$(MKDIR_P) $(dir $@)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
+sfml: sfml.zip
+	unzip -d sfml sfml.zip
+
+sfml.zip:
+	curl -Lo sfml.zip https://www.sfml-dev.org/files/SFML-2.5.1-windows-gcc-7.3.0-mingw-64-bit.zip
 
 .PHONY: clean
 


### PR DESCRIPTION
Run `choco install mingw unzip curl` to set up everything you need to build and run. You'll need to close and reopen your terminal, or run `refreshenv`.

Then to build, run `make`, and to run, use `bin/square.exe`.

Building and running should work fine in VSCode as well now.